### PR TITLE
Feature: D4 — FastAPI REST API, serve CLI command, Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml .
+COPY fairness_pipeline_dev_toolkit/ ./fairness_pipeline_dev_toolkit/
+COPY fairpipe/ ./fairpipe/
+RUN pip install --no-cache-dir ".[api]"
+EXPOSE 8000
+CMD ["fairpipe", "serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  fairpipe:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - FAIRPIPE_MIN_GROUP_SIZE=30

--- a/fairness_pipeline_dev_toolkit/api/__init__.py
+++ b/fairness_pipeline_dev_toolkit/api/__init__.py
@@ -1,0 +1,4 @@
+from .app import create_app
+from .store import ResultStore
+
+__all__ = ["create_app", "ResultStore"]

--- a/fairness_pipeline_dev_toolkit/api/app.py
+++ b/fairness_pipeline_dev_toolkit/api/app.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from .routes import health_router, pipeline_router, validate_router, workflow_router
+from .routes.validate import get_store
+from .store import ResultStore
+
+logger = logging.getLogger(__name__)
+
+_API_VERSION = "0.7.0"
+
+
+def create_app() -> FastAPI:
+    """Factory that creates and configures the FastAPI application."""
+    app = FastAPI(
+        title="fairpipe API",
+        version=_API_VERSION,
+        description=(
+            "REST API for the fairpipe fairness toolkit. "
+            "Compute fairness metrics, run bias pipelines, and execute full workflows over HTTP."
+        ),
+    )
+
+    # Singleton store attached to app state
+    store = ResultStore()
+    app.state.store = store
+
+    # Wire the store into the dependency system
+    def _get_store() -> ResultStore:
+        return app.state.store
+
+    app.dependency_overrides[get_store] = _get_store
+
+    # Register routers
+    app.include_router(health_router)
+    app.include_router(validate_router)
+    app.include_router(pipeline_router)
+    app.include_router(workflow_router)
+
+    # Global exception handler — returns 500 for any unhandled exception.
+    # Note: HTTPException is handled by FastAPI before reaching this handler.
+    @app.exception_handler(Exception)
+    async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+        logger.exception("Unhandled exception on %s: %s", request.url.path, exc)
+        return JSONResponse(
+            status_code=500,
+            content={"error": "InternalServerError", "message": str(exc), "run_id": None},
+        )
+
+    return app

--- a/fairness_pipeline_dev_toolkit/api/models/__init__.py
+++ b/fairness_pipeline_dev_toolkit/api/models/__init__.py
@@ -1,0 +1,19 @@
+from .requests import ValidateRequest
+from .responses import (
+    ErrorResponse,
+    HealthResponse,
+    PipelineResponse,
+    ResultResponse,
+    ValidateResponse,
+    WorkflowResponse,
+)
+
+__all__ = [
+    "ValidateRequest",
+    "HealthResponse",
+    "ValidateResponse",
+    "PipelineResponse",
+    "WorkflowResponse",
+    "ErrorResponse",
+    "ResultResponse",
+]

--- a/fairness_pipeline_dev_toolkit/api/models/requests.py
+++ b/fairness_pipeline_dev_toolkit/api/models/requests.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, model_validator
+
+
+class ValidateRequest(BaseModel):
+    y_pred: List[Union[int, float]]
+    sensitive: List[Union[str, int]]
+    y_true: Optional[List[Union[int, float]]] = None
+    y_score: Optional[List[float]] = None
+    with_ci: bool = False
+    ci_level: float = 0.95
+    with_effects: bool = False
+    min_group_size: int = 30
+    backend: Optional[str] = None
+    threshold: Optional[float] = None
+
+    @model_validator(mode="after")
+    def check_lengths(self) -> "ValidateRequest":
+        n = len(self.y_pred)
+        m = len(self.sensitive)
+        if m != n:
+            raise ValueError(f"y_pred length ({n}) must equal sensitive length ({m})")
+        if self.y_true is not None and len(self.y_true) != n:
+            raise ValueError(f"y_true length ({len(self.y_true)}) must equal y_pred length ({n})")
+        if self.y_score is not None and len(self.y_score) != n:
+            raise ValueError(f"y_score length ({len(self.y_score)}) must equal y_pred length ({n})")
+        return self

--- a/fairness_pipeline_dev_toolkit/api/models/responses.py
+++ b/fairness_pipeline_dev_toolkit/api/models/responses.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+    timestamp: str
+
+
+class ValidateResponse(BaseModel):
+    run_id: str
+    status: str = "success"
+    passed: bool
+    metrics: Dict[str, Any]
+    timestamp: str
+
+
+class PipelineResponse(BaseModel):
+    run_id: str
+    status: str = "success"
+    detector_report: Dict[str, Any]
+    transformed_rows: int
+    transformers_applied: List[str]
+    timestamp: str
+
+
+class WorkflowResponse(BaseModel):
+    run_id: str
+    status: str = "success"
+    validation: Dict[str, Any]
+    baseline_metrics: Dict[str, Any]
+    final_metrics: Dict[str, Any]
+    timestamp: str
+
+
+class ErrorResponse(BaseModel):
+    error: str
+    message: str
+    run_id: Optional[str] = None
+
+
+class ResultResponse(BaseModel):
+    run_id: str
+    endpoint: str
+    result: Dict[str, Any]
+    created_at: str

--- a/fairness_pipeline_dev_toolkit/api/routes/__init__.py
+++ b/fairness_pipeline_dev_toolkit/api/routes/__init__.py
@@ -1,0 +1,6 @@
+from .health import router as health_router
+from .pipeline import router as pipeline_router
+from .validate import router as validate_router
+from .workflow import router as workflow_router
+
+__all__ = ["health_router", "validate_router", "pipeline_router", "workflow_router"]

--- a/fairness_pipeline_dev_toolkit/api/routes/health.py
+++ b/fairness_pipeline_dev_toolkit/api/routes/health.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+from ..models.responses import HealthResponse
+
+router = APIRouter()
+
+_API_VERSION = "0.7.0"
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    return HealthResponse(
+        status="ok",
+        version=_API_VERSION,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )

--- a/fairness_pipeline_dev_toolkit/api/routes/pipeline.py
+++ b/fairness_pipeline_dev_toolkit/api/routes/pipeline.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+
+from fairness_pipeline_dev_toolkit.io import load_data
+from fairness_pipeline_dev_toolkit.pipeline.config import load_config
+from fairness_pipeline_dev_toolkit.pipeline.orchestration import (
+    apply_pipeline,
+    build_pipeline,
+    run_detectors,
+)
+
+from ..models.responses import PipelineResponse
+from ..store import ResultStore
+from .validate import get_store
+
+router = APIRouter()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@router.post("/pipeline", response_model=PipelineResponse)
+async def pipeline_run(
+    file: UploadFile = File(...),
+    config: str = Form(...),
+    store: ResultStore = Depends(get_store),
+):
+    run_id = str(uuid.uuid4())
+    ts = _utc_now()
+
+    contents = await file.read()
+    filename = file.filename or "upload.csv"
+    suffix = ".parquet" if filename.endswith((".parquet", ".pq")) else ".csv"
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(contents)
+            tmp_path = tmp.name
+
+        df = load_data(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    cfg = load_config(text=config)
+
+    bias_report = run_detectors(df, cfg)
+
+    try:
+        pipe = build_pipeline(cfg)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    Xt, _ = apply_pipeline(pipe, df)
+    transformers_applied = [name for name, _ in pipe.steps]
+
+    detector_dict = bias_report.to_dict()
+
+    result: dict[str, Any] = {
+        "run_id": run_id,
+        "status": "success",
+        "detector_report": detector_dict,
+        "transformed_rows": len(Xt),
+        "transformers_applied": transformers_applied,
+        "timestamp": ts,
+        "_endpoint": "/pipeline",
+    }
+    store.put(run_id, result)
+
+    return PipelineResponse(
+        run_id=run_id,
+        detector_report=detector_dict,
+        transformed_rows=len(Xt),
+        transformers_applied=transformers_applied,
+        timestamp=ts,
+    )

--- a/fairness_pipeline_dev_toolkit/api/routes/validate.py
+++ b/fairness_pipeline_dev_toolkit/api/routes/validate.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import numpy as np
+from fastapi import APIRouter, Depends, HTTPException
+
+from fairness_pipeline_dev_toolkit.metrics import FairnessAnalyzer
+
+from ..models.requests import ValidateRequest
+from ..models.responses import ValidateResponse
+from ..store import ResultStore
+
+router = APIRouter()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_float(v) -> Optional[float]:
+    """Convert numpy scalar to Python float; return None for NaN/inf."""
+    if v is None:
+        return None
+    try:
+        f = float(v)
+        return None if (math.isnan(f) or math.isinf(f)) else f
+    except (TypeError, ValueError):
+        return None
+
+
+def _result_to_dict(r) -> Dict[str, Any]:
+    """Serialize a metrics.core.Result dataclass to a JSON-safe dict."""
+    ci = None
+    if r.ci is not None:
+        ci = [_safe_float(r.ci[0]), _safe_float(r.ci[1])]
+    n_per_group = None
+    if r.n_per_group is not None:
+        n_per_group = {str(k): int(v) for k, v in r.n_per_group.items()}
+    return {
+        "metric": r.metric,
+        "value": _safe_float(r.value),
+        "ci": ci,
+        "effect_size": _safe_float(r.effect_size),
+        "n_per_group": n_per_group,
+    }
+
+
+def get_store(request: Any = None) -> ResultStore:
+    # Replaced by app.dependency_overrides in create_app()
+    raise RuntimeError("ResultStore dependency not configured")  # pragma: no cover
+
+
+@router.post("/validate", response_model=ValidateResponse)
+async def validate(req: ValidateRequest, store: ResultStore = Depends(get_store)):
+    run_id = str(uuid.uuid4())
+    ts = _utc_now()
+
+    analyzer = FairnessAnalyzer(min_group_size=req.min_group_size, backend=req.backend)
+    y_pred = np.array(req.y_pred)
+    sensitive = np.array(req.sensitive)
+
+    metrics: Dict[str, Any] = {}
+
+    dpd = analyzer.demographic_parity_difference(
+        y_pred=y_pred,
+        sensitive=sensitive,
+        with_ci=req.with_ci,
+        ci_level=req.ci_level,
+        with_effect_size=req.with_effects,
+    )
+    metrics["demographic_parity_difference"] = _result_to_dict(dpd)
+
+    if req.y_true is not None:
+        y_true = np.array(req.y_true)
+        eod = analyzer.equalized_odds_difference(
+            y_true=y_true,
+            y_pred=y_pred,
+            sensitive=sensitive,
+            with_ci=req.with_ci,
+            ci_level=req.ci_level,
+            with_effect_size=req.with_effects,
+        )
+        metrics["equalized_odds_difference"] = _result_to_dict(eod)
+
+    if req.y_score is not None and req.y_true is not None:
+        y_score = np.array(req.y_score)
+        mae = analyzer.mae_parity_difference(
+            y_true=np.array(req.y_true),
+            y_pred=y_score,
+            sensitive=sensitive,
+            with_ci=req.with_ci,
+            ci_level=req.ci_level,
+            with_effect_size=req.with_effects,
+        )
+        metrics["mae_parity_difference"] = _result_to_dict(mae)
+
+    dpd_value = metrics["demographic_parity_difference"]["value"]
+    passed = True
+    if req.threshold is not None and dpd_value is not None:
+        passed = abs(dpd_value) <= req.threshold
+
+    result = {
+        "run_id": run_id,
+        "status": "success",
+        "passed": passed,
+        "metrics": metrics,
+        "timestamp": ts,
+        "_endpoint": "/validate",
+    }
+    store.put(run_id, result)
+
+    return ValidateResponse(
+        run_id=run_id,
+        passed=passed,
+        metrics=metrics,
+        timestamp=ts,
+    )
+
+
+@router.get("/results/{run_id}")
+async def get_result(run_id: str, store: ResultStore = Depends(get_store)):
+    data = store.get(run_id)
+    if data is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "NotFound", "message": f"No result found for run_id: {run_id}"},
+        )
+    endpoint = data.pop("_endpoint", "/validate")
+    created_at = data.get("timestamp", "")
+    return {
+        "run_id": run_id,
+        "endpoint": endpoint,
+        "result": data,
+        "created_at": created_at,
+    }

--- a/fairness_pipeline_dev_toolkit/api/routes/workflow.py
+++ b/fairness_pipeline_dev_toolkit/api/routes/workflow.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+
+from fairness_pipeline_dev_toolkit.integration.orchestrator import execute_workflow
+from fairness_pipeline_dev_toolkit.io import load_data
+from fairness_pipeline_dev_toolkit.pipeline.config import load_config
+
+from ..models.responses import WorkflowResponse
+from ..store import ResultStore
+from .validate import _safe_float, get_store
+
+router = APIRouter()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _serialize_metrics(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a dict of Result dataclasses (or plain values) to JSON-safe dicts."""
+    out: Dict[str, Any] = {}
+    for key, val in metrics.items():
+        if hasattr(val, "value") and hasattr(val, "metric"):
+            # metrics.core.Result dataclass
+            ci: Optional[list] = None
+            if val.ci is not None:
+                ci = [_safe_float(val.ci[0]), _safe_float(val.ci[1])]
+            n_per_group: Optional[dict] = None
+            if val.n_per_group is not None:
+                n_per_group = {str(k): int(v) for k, v in val.n_per_group.items()}
+            out[key] = {
+                "metric": val.metric,
+                "value": _safe_float(val.value),
+                "ci": ci,
+                "effect_size": _safe_float(val.effect_size),
+                "n_per_group": n_per_group,
+            }
+        else:
+            try:
+                f = float(val)
+                out[key] = None if (math.isnan(f) or math.isinf(f)) else f
+            except (TypeError, ValueError):
+                out[key] = str(val)
+    return out
+
+
+@router.post("/workflow", response_model=WorkflowResponse)
+async def workflow_run(
+    file: UploadFile = File(...),
+    config: str = Form(...),
+    min_group_size: int = Form(30),
+    train_size: float = Form(0.8),
+    store: ResultStore = Depends(get_store),
+):
+    run_id = str(uuid.uuid4())
+    ts = _utc_now()
+
+    contents = await file.read()
+    filename = file.filename or "upload.csv"
+    suffix = ".parquet" if filename.endswith((".parquet", ".pq")) else ".csv"
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(contents)
+            tmp_path = tmp.name
+
+        df = load_data(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    cfg = load_config(text=config)
+
+    wf_result = execute_workflow(
+        config=cfg,
+        df=df,
+        output_dir=None,
+        min_group_size=min_group_size,
+        train_size=train_size,
+    )
+
+    vr = wf_result.validation_result
+    validation_dict: Dict[str, Any] = {
+        "passed": vr.passed,
+        "message": vr.message,
+        "improvement": _safe_float(vr.improvement),
+        "baseline_metric_value": _safe_float(vr.baseline_metric_value),
+        "final_metric_value": _safe_float(vr.final_metric_value),
+        "threshold": _safe_float(vr.threshold),
+    }
+
+    baseline = _serialize_metrics(wf_result.baseline_metrics)
+    final = _serialize_metrics(wf_result.final_metrics)
+
+    result: Dict[str, Any] = {
+        "run_id": run_id,
+        "status": "success",
+        "validation": validation_dict,
+        "baseline_metrics": baseline,
+        "final_metrics": final,
+        "timestamp": ts,
+        "_endpoint": "/workflow",
+    }
+    store.put(run_id, result)
+
+    return WorkflowResponse(
+        run_id=run_id,
+        validation=validation_dict,
+        baseline_metrics=baseline,
+        final_metrics=final,
+        timestamp=ts,
+    )

--- a/fairness_pipeline_dev_toolkit/api/store.py
+++ b/fairness_pipeline_dev_toolkit/api/store.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from typing import Optional
+
+_MAX_ENTRIES = 500
+
+
+class ResultStore:
+    """Thread-safe in-memory store for API run results.
+
+    Capped at *maxsize* entries; the oldest entry is evicted when full (LRU).
+    """
+
+    def __init__(self, maxsize: int = _MAX_ENTRIES) -> None:
+        self._store: OrderedDict[str, dict] = OrderedDict()
+        self._lock = threading.Lock()
+        self._maxsize = maxsize
+
+    def put(self, run_id: str, result: dict) -> None:
+        with self._lock:
+            if run_id in self._store:
+                self._store.move_to_end(run_id)
+            self._store[run_id] = result
+            while len(self._store) > self._maxsize:
+                self._store.popitem(last=False)  # evict oldest
+
+    def get(self, run_id: str) -> Optional[dict]:
+        with self._lock:
+            if run_id not in self._store:
+                return None
+            self._store.move_to_end(run_id)  # refresh on read
+            return self._store[run_id]
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)

--- a/fairness_pipeline_dev_toolkit/cli/main.py
+++ b/fairness_pipeline_dev_toolkit/cli/main.py
@@ -584,6 +584,44 @@ def cmd_run_pipeline(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_serve(args: argparse.Namespace) -> int:
+    """Start the fairpipe REST API server."""
+    try:
+        import uvicorn  # noqa: PLC0415
+
+        from fairness_pipeline_dev_toolkit.api.app import create_app  # noqa: PLC0415
+    except ImportError:
+        print(
+            "Error: REST API requires fairpipe[api]. " "Install with: pip install 'fairpipe[api]'"
+        )
+        return 1
+
+    host: str = args.host
+    port: int = args.port
+
+    print(f"fairpipe API v0.7.0 running on http://{host}:{port}")
+    print(f"  → Swagger UI: http://{host}:{port}/docs")
+    print(f"  → ReDoc:      http://{host}:{port}/redoc")
+
+    if args.reload:
+        uvicorn.run(
+            "fairness_pipeline_dev_toolkit.api.app:create_app",
+            factory=True,
+            host=host,
+            port=port,
+            reload=True,
+        )
+    else:
+        workers = args.workers if args.workers > 1 else 1
+        uvicorn.run(
+            create_app(),
+            host=host,
+            port=port,
+            workers=workers,
+        )
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     """Main CLI entry point."""
     # Set up logging based on environment or defaults
@@ -741,6 +779,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     p_run.add_argument("--mlflow-run-name", help="MLflow run name (optional)")
     p_run.set_defaults(func=cmd_run_pipeline)
+
+    # REST API server
+    p_serve = sub.add_parser("serve", help="Start the fairpipe REST API server")
+    p_serve.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    p_serve.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000)")
+    p_serve.add_argument("--reload", action="store_true", help="Enable auto-reload for development")
+    p_serve.add_argument(
+        "--workers", type=int, default=1, help="Number of worker processes (default: 1)"
+    )
+    p_serve.set_defaults(func=cmd_serve)
 
     args = parser.parse_args(argv)
     if not hasattr(args, "func"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ adapters = [
   "fairlearn>=0.10",
   "aequitas>=0.42 ; python_version < \"3.12\"",
 ]
+api = [
+  "fastapi[standard]>=0.111.0",
+  "python-multipart>=0.0.9",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,0 +1,168 @@
+"""
+Tests for the fairpipe REST API.
+
+Requires: pip install fairpipe[api]
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fairness_pipeline_dev_toolkit.api.app import create_app
+
+
+@pytest.fixture(scope="module")
+def client():
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+def test_health(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["version"] == "0.7.0"
+    assert "timestamp" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /validate — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_validate_basic(client):
+    payload = {
+        "y_pred": [1, 0, 1, 0, 1, 0],
+        "sensitive": ["A", "A", "A", "B", "B", "B"],
+        "min_group_size": 1,
+    }
+    r = client.post("/validate", json=payload)
+    assert r.status_code == 200
+    body = r.json()
+    assert "run_id" in body
+    assert "metrics" in body
+    assert "passed" in body
+    assert "demographic_parity_difference" in body["metrics"]
+
+
+# ---------------------------------------------------------------------------
+# POST /validate — mismatched array lengths → 422
+# ---------------------------------------------------------------------------
+
+
+def test_validate_mismatched_lengths(client):
+    payload = {
+        "y_pred": [1, 0, 1],
+        "sensitive": ["A", "B"],  # length mismatch
+    }
+    r = client.post("/validate", json=payload)
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /validate then GET /results/{run_id}
+# ---------------------------------------------------------------------------
+
+
+def test_validate_stores_result(client):
+    payload = {
+        "y_pred": [1, 0, 1, 0],
+        "sensitive": ["A", "A", "B", "B"],
+        "min_group_size": 1,
+    }
+    r = client.post("/validate", json=payload)
+    assert r.status_code == 200
+    run_id = r.json()["run_id"]
+
+    r2 = client.get(f"/results/{run_id}")
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["run_id"] == run_id
+
+
+# ---------------------------------------------------------------------------
+# GET /results/{run_id} — not found → 404
+# ---------------------------------------------------------------------------
+
+
+def test_results_not_found(client):
+    r = client.get("/results/nonexistent-run-id-that-does-not-exist")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# passed=false must return 200, not 500
+# ---------------------------------------------------------------------------
+
+
+def test_validate_passed_false_is_not_500(client):
+    # group A always predicted 1, group B always predicted 0 → DPD = 1.0
+    payload = {
+        "y_pred": [1] * 50 + [0] * 50,
+        "sensitive": ["A"] * 50 + ["B"] * 50,
+        "threshold": 0.01,  # tight threshold → passed=False
+        "min_group_size": 10,
+    }
+    r = client.post("/validate", json=payload)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /docs → 200 (Swagger UI accessible)
+# ---------------------------------------------------------------------------
+
+
+def test_docs_accessible(client):
+    r = client.get("/docs")
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Concurrent store — thread safety
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_store(client):
+    results: dict[str, str] = {}
+    errors: list[Exception] = []
+
+    def post(key: str) -> None:
+        try:
+            payload = {
+                "y_pred": [1, 0, 1, 0],
+                "sensitive": ["A", "A", "B", "B"],
+                "min_group_size": 1,
+            }
+            r = client.post("/validate", json=payload)
+            assert r.status_code == 200
+            results[key] = r.json()["run_id"]
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=post, args=("t1",))
+    t2 = threading.Thread(target=post, args=("t2",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    assert "t1" in results and "t2" in results
+    assert results["t1"] != results["t2"]
+
+    r1 = client.get(f"/results/{results['t1']}")
+    r2 = client.get(f"/results/{results['t2']}")
+    assert r1.status_code == 200
+    assert r2.status_code == 200


### PR DESCRIPTION
  Add an optional REST API (pip install fairpipe[api]) exposing 5 endpoints:
  GET /health, POST /validate, POST /pipeline, POST /workflow,
  GET /results/{run_id}. Includes a thread-safe in-memory ResultStore,
  Swagger UI at /docs, fairpipe serve CLI command (lazy uvicorn import),
  Dockerfile + docker-compose.yml, and 8 new API tests (733 total passing).